### PR TITLE
Change GA4 ID for each channel

### DIFF
--- a/src/Factory/RenderHeadTwigFactory.php
+++ b/src/Factory/RenderHeadTwigFactory.php
@@ -11,16 +11,22 @@ declare(strict_types=1);
 namespace Spinbits\SyliusGoogleAnalytics4Plugin\Factory;
 
 use Twig\Environment;
+use Sylius\Component\Channel\Context\ChannelContextInterface;
 
 class RenderHeadTwigFactory
 {
+    /** @var ChannelContextInterface */
+    private $channelContext;
+
+
     public function __construct(
+        ChannelContextInterface $channelContext,
         private Environment $twig,
-        private string $id,
         private string $additionalParams,
         private string $templateName,
         private bool $enabled
     ) {
+        $this->channelContext = $channelContext;
         $this->additionalParams = $additionalParams ? '&'.trim($additionalParams,'&') : '';
     }
 
@@ -28,7 +34,7 @@ class RenderHeadTwigFactory
     {
         return !$this->enabled ? '' : $this->twig->render(
             $this->templateName, [
-                'id' => $this->id,
+                'id' => $this->channelContext->getChannel()->getGoogle(),
                 'url_suffix' => $this->additionalParams
             ]
         );

--- a/src/Resources/config/services.yaml
+++ b/src/Resources/config/services.yaml
@@ -13,19 +13,19 @@ services:
 
     Spinbits\SyliusGoogleAnalytics4Plugin\Factory\RenderHeadTwigFactory:
         arguments:
-            $id: '%spinbits_sylius_google_analytics4.id%'
+            $channelContext: '@sylius.context.channel'
             $enabled: '%spinbits_sylius_google_analytics4.enabled%'
             $additionalParams: '%spinbits_sylius_google_analytics4.additionalParameters%'
             $templateName: '%spinbits_sylius_google_analytics4.templateName%'
-            
+    
     Spinbits\SyliusGoogleAnalytics4Plugin\EventListener\RenderViewListener:
         tags:
             - { name: kernel.event_listener, event: kernel.response, method: onKernelResponse }
-            
+    
     Spinbits\SyliusGoogleAnalytics4Plugin\Factory\ItemFactory:
         arguments:
             $productVariantResolver: '@sylius.product_variant_resolver.default'
-            
+    
     Spinbits\SyliusGoogleAnalytics4Plugin\Factory\EventsBagSessionFactory:
         decorates: session.factory
         arguments: ['@.inner']


### PR DESCRIPTION
We need for each channel GA4 ID. I think the ID has to be in channel admin. When created a channel.
So Sylius admin/entity/form must be add field google.