### PR TITLE
Pushing product Name & code instead of variant Name &  id

### DIFF
--- a/src/Factory/ItemFactory.php
+++ b/src/Factory/ItemFactory.php
@@ -49,8 +49,8 @@ class ItemFactory
         $mainTaxon = $product?->getMainTaxon();
 
         return new Item(
-            (string) $variant->getId(),
-            (string) $variant->getCode(),
+            (string) $product->getCode(),
+            (string) $product->getName(),
             round($price/100, 2),
             $this->currencyContext->getCurrencyCode(),
             0,


### PR DESCRIPTION
in any item related event
item_id field was populated with product variant auto generated id,  it s replaced by product code
item_name was populated with variant code , it s replaced by product product name