### PR TITLE
Request array symfony 6.0

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,3 +1,8 @@
+# UPGRADE FROM `1.1` TO `1.2`
+
+## Changes
+* Added Symfony 6 support
+
 # UPGRADE FROM `1.0` TO `1.1`
 
 ## Changes

--- a/src/EventListener/NavigationEventListener.php
+++ b/src/EventListener/NavigationEventListener.php
@@ -93,7 +93,7 @@ class NavigationEventListener implements EventSubscriberInterface
     private function getSearchTerm(Request $request): ?string
     {
         /** @var array<string, array<string, string|null|int>> $criteria */
-        $criteria = (array) $request->query->get('criteria');
+        $criteria = (array) $request->query->all('criteria');
         return (isset($criteria['search']['value']))
             ? (string) $criteria['search']['value']
             : null;

--- a/src/EventListener/NavigationEventListener.php
+++ b/src/EventListener/NavigationEventListener.php
@@ -93,7 +93,7 @@ class NavigationEventListener implements EventSubscriberInterface
     private function getSearchTerm(Request $request): ?string
     {
         /** @var array<string, array<string, string|null|int>> $criteria */
-        $criteria = (array) $request->query->all('criteria');
+        $criteria = $request->query->all('criteria');
         return (isset($criteria['search']['value']))
             ? (string) $criteria['search']['value']
             : null;


### PR DESCRIPTION
Issue #31
 
With symfony 6.x it's not possible to get array values from the request parameters with the get() method.
Use all() instead.
